### PR TITLE
Add support to handle space in NSLocalizedString

### DIFF
--- a/objc_strings.py
+++ b/objc_strings.py
@@ -59,7 +59,7 @@ def key_in_string(s):
     return key
 
 def key_in_code_line(s):
-    matches = re.findall("NSLocalizedString.*\(@?\"(.*?)\",", s);
+    matches = re.findall("NSLocalizedString.*\(\s?@?\"(.*?)\",", s);
     if len(matches) == 0:
         return None;
 


### PR DESCRIPTION
If there was a space after the opening parenthesis when using the NSLocalizedString macro, the regular express failed to match on it. This change adds support for that space.
